### PR TITLE
feat: #6 어드민 FE (이벤트 목록/AI 생성/대시보드)

### DIFF
--- a/src/api/admin.events.api.ts
+++ b/src/api/admin.events.api.ts
@@ -1,0 +1,108 @@
+import client from './client'
+
+export interface GradeConfig {
+  grade: string
+  price: number
+  seatCount: number
+}
+
+export interface ZoneConfig {
+  zone: string
+  grade: string
+  seatCount: number
+}
+
+export interface AiGenerateResponse {
+  title: string
+  artist: string | null
+  venue: string
+  dateTime: string
+  totalSeats: number
+  trackPolicy: string
+  grades: GradeConfig[]
+  zones: ZoneConfig[]
+}
+
+export interface AdminEventCreateRequest {
+  title: string
+  artist: string | null
+  venue: string
+  dateTime: string
+  totalSeats: number
+  ticketOpenAt: string
+  ticketCloseAt: string
+  trackPolicy: string
+  tenantId: string
+  grades: GradeConfig[]
+  zones: ZoneConfig[]
+}
+
+export interface AdminEventResponse {
+  concertId: number
+  scheduleId: number
+  title: string
+  artist: string | null
+  venue: string
+  tenantId: string
+  dateTime: string
+  totalSeats: number
+  ticketOpenAt: string
+  ticketCloseAt: string
+  trackPolicy: string
+  status: string
+  grades?: { grade: string; price: number }[]
+  zones?: ZoneConfig[]
+}
+
+export interface GradeStat {
+  grade: string
+  totalSeats: number
+  soldSeats: number
+  availableSeats: number
+}
+
+export interface AdminDashboardResponse {
+  scheduleId: number
+  title: string
+  status: string
+  totalSeats: number
+  soldSeats: number
+  availableSeats: number
+  gradeStats: GradeStat[]
+}
+
+export const adminEventsApi = {
+  async aiGenerate(prompt: string): Promise<AiGenerateResponse> {
+    const { data } = await client.post('/v1/admin/events/ai-generate', { prompt })
+    return data
+  },
+
+  async create(request: AdminEventCreateRequest): Promise<AdminEventResponse> {
+    const { data } = await client.post('/v1/admin/events', request)
+    return data
+  },
+
+  async list(): Promise<AdminEventResponse[]> {
+    const { data } = await client.get('/v1/admin/events')
+    return data
+  },
+
+  async get(scheduleId: number): Promise<AdminEventResponse> {
+    const { data } = await client.get(`/v1/admin/events/${scheduleId}`)
+    return data
+  },
+
+  async update(scheduleId: number, request: AdminEventCreateRequest): Promise<AdminEventResponse> {
+    const { data } = await client.put(`/v1/admin/events/${scheduleId}`, request)
+    return data
+  },
+
+  async delete(scheduleId: number): Promise<void> {
+    await client.delete(`/v1/admin/events/${scheduleId}`)
+  },
+
+  async dashboard(scheduleId: number): Promise<AdminDashboardResponse> {
+    const { data } = await client.get(`/v1/admin/events/${scheduleId}/dashboard`)
+    return data
+  },
+}

--- a/src/components/layout/SiteHeader.vue
+++ b/src/components/layout/SiteHeader.vue
@@ -9,6 +9,7 @@ const mobileOpen = ref(false)
 const navLinks = [
   { label: 'Concerts', to: '/concerts' },
   { label: 'My Tickets', to: '/my/tickets' },
+  { label: 'Admin', to: '/admin/events' },
 ]
 </script>
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -66,6 +66,24 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/admin/events',
+      name: 'admin-events',
+      component: () => import('@/views/AdminEventsPage.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/admin/events/new',
+      name: 'admin-event-create',
+      component: () => import('@/views/AdminEventCreatePage.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/admin/events/:id',
+      name: 'admin-dashboard',
+      component: () => import('@/views/AdminDashboardPage.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/:pathMatch(.*)*',
       name: 'not-found',
       component: () => import('@/views/NotFoundPage.vue'),

--- a/src/views/AdminDashboardPage.vue
+++ b/src/views/AdminDashboardPage.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ArrowLeft, Calendar, MapPin, Users, TrendingUp, Ticket } from 'lucide-vue-next'
+import { adminEventsApi, type AdminEventResponse, type AdminDashboardResponse } from '@/api/admin.events.api'
+
+const route = useRoute()
+const router = useRouter()
+const scheduleId = Number(route.params.id)
+
+const event = ref<AdminEventResponse | null>(null)
+const dashboard = ref<AdminDashboardResponse | null>(null)
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    const [e, d] = await Promise.all([
+      adminEventsApi.get(scheduleId),
+      adminEventsApi.dashboard(scheduleId),
+    ])
+    event.value = e
+    dashboard.value = d
+  } catch (e) {
+    console.error('조회 실패', e)
+  } finally {
+    loading.value = false
+  }
+})
+
+const soldPercent = computed(() => {
+  if (!dashboard.value || !dashboard.value.totalSeats) return 0
+  return Math.round((dashboard.value.soldSeats / dashboard.value.totalSeats) * 100)
+})
+
+const statusLabel: Record<string, string> = {
+  UPCOMING: '예정',
+  OPEN: '판매중',
+  CLOSED: '마감',
+  COMPLETED: '완료',
+}
+
+const statusColor: Record<string, string> = {
+  UPCOMING: 'bg-yellow-500/20 text-yellow-400',
+  OPEN: 'bg-green-500/20 text-green-400',
+  CLOSED: 'bg-red-500/20 text-red-400',
+  COMPLETED: 'bg-gray-500/20 text-gray-400',
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-5xl px-4 lg:px-8 py-8">
+    <button
+      class="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-6 transition-colors"
+      @click="router.push('/admin/events')"
+    >
+      <ArrowLeft class="w-4 h-4" />
+      이벤트 목록
+    </button>
+
+    <div v-if="loading" class="space-y-4">
+      <div class="h-32 rounded-xl skeleton" />
+      <div class="h-64 rounded-xl skeleton" />
+    </div>
+
+    <template v-else-if="event && dashboard">
+      <!-- 이벤트 헤더 -->
+      <div class="bg-card border border-border rounded-xl p-6 mb-6">
+        <div class="flex items-start justify-between mb-4">
+          <div>
+            <h1 class="text-2xl font-display font-bold text-foreground mb-2">{{ event.title }}</h1>
+            <p v-if="event.artist" class="text-muted-foreground">{{ event.artist }}</p>
+          </div>
+          <span
+            class="px-3 py-1 rounded-full text-sm font-medium"
+            :class="statusColor[event.status] || 'bg-gray-500/20 text-gray-400'"
+          >
+            {{ statusLabel[event.status] || event.status }}
+          </span>
+        </div>
+        <div class="flex flex-wrap gap-4 text-sm text-muted-foreground">
+          <span class="flex items-center gap-1.5">
+            <MapPin class="w-4 h-4" /> {{ event.venue }}
+          </span>
+          <span class="flex items-center gap-1.5">
+            <Calendar class="w-4 h-4" /> {{ new Date(event.dateTime).toLocaleString('ko-KR') }}
+          </span>
+          <span class="flex items-center gap-1.5">
+            <Users class="w-4 h-4" /> {{ event.totalSeats?.toLocaleString() }}석
+          </span>
+          <span class="px-2 py-0.5 rounded text-xs font-mono bg-secondary">
+            {{ event.trackPolicy }}
+          </span>
+        </div>
+      </div>
+
+      <!-- 요약 카드 -->
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div class="bg-card border border-border rounded-xl p-5">
+          <div class="flex items-center gap-2 text-muted-foreground text-sm mb-2">
+            <Ticket class="w-4 h-4" /> 총 좌석
+          </div>
+          <p class="text-2xl font-display font-bold text-foreground">
+            {{ dashboard.totalSeats.toLocaleString() }}
+          </p>
+        </div>
+        <div class="bg-card border border-border rounded-xl p-5">
+          <div class="flex items-center gap-2 text-muted-foreground text-sm mb-2">
+            <TrendingUp class="w-4 h-4" /> 판매량
+          </div>
+          <p class="text-2xl font-display font-bold text-green-400">
+            {{ dashboard.soldSeats.toLocaleString() }}
+          </p>
+        </div>
+        <div class="bg-card border border-border rounded-xl p-5">
+          <div class="flex items-center gap-2 text-muted-foreground text-sm mb-2">
+            <Users class="w-4 h-4" /> 잔여석
+          </div>
+          <p class="text-2xl font-display font-bold text-foreground">
+            {{ dashboard.availableSeats.toLocaleString() }}
+          </p>
+        </div>
+      </div>
+
+      <!-- 전체 판매율 -->
+      <div class="bg-card border border-border rounded-xl p-6 mb-6">
+        <div class="flex items-center justify-between mb-3">
+          <h2 class="text-lg font-display font-semibold text-foreground">판매율</h2>
+          <span class="text-2xl font-display font-bold text-primary">{{ soldPercent }}%</span>
+        </div>
+        <div class="h-3 bg-secondary rounded-full overflow-hidden">
+          <div
+            class="h-full bg-primary rounded-full transition-all duration-700"
+            :style="{ width: `${soldPercent}%` }"
+          />
+        </div>
+      </div>
+
+      <!-- 등급별 현황 -->
+      <div class="bg-card border border-border rounded-xl p-6">
+        <h2 class="text-lg font-display font-semibold text-foreground mb-4">등급별 현황</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border text-muted-foreground">
+                <th class="text-left py-3 pr-4">등급</th>
+                <th class="text-right py-3 pr-4">총 좌석</th>
+                <th class="text-right py-3 pr-4">판매</th>
+                <th class="text-right py-3 pr-4">잔여</th>
+                <th class="text-right py-3">판매율</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="stat in dashboard.gradeStats"
+                :key="stat.grade"
+                class="border-b border-border/50"
+              >
+                <td class="py-3 pr-4 font-medium text-foreground">{{ stat.grade }}</td>
+                <td class="py-3 pr-4 text-right text-muted-foreground">{{ stat.totalSeats.toLocaleString() }}</td>
+                <td class="py-3 pr-4 text-right text-green-400">{{ stat.soldSeats.toLocaleString() }}</td>
+                <td class="py-3 pr-4 text-right text-foreground">{{ stat.availableSeats.toLocaleString() }}</td>
+                <td class="py-3 text-right">
+                  <span class="text-primary font-medium">
+                    {{ stat.totalSeats > 0 ? Math.round((stat.soldSeats / stat.totalSeats) * 100) : 0 }}%
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/views/AdminEventCreatePage.vue
+++ b/src/views/AdminEventCreatePage.vue
@@ -1,0 +1,267 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { Sparkles, Loader2, ArrowLeft, Save } from 'lucide-vue-next'
+import { adminEventsApi, type AiGenerateResponse, type GradeConfig, type ZoneConfig } from '@/api/admin.events.api'
+
+const router = useRouter()
+
+// AI 생성
+const prompt = ref('')
+const aiLoading = ref(false)
+const aiGenerated = ref(false)
+
+// 폼 상태
+const title = ref('')
+const artist = ref('')
+const venue = ref('')
+const dateTime = ref('')
+const totalSeats = ref(0)
+const trackPolicy = ref('DUAL_TRACK')
+const ticketOpenAt = ref('')
+const ticketCloseAt = ref('')
+const tenantId = ref('default')
+const grades = ref<GradeConfig[]>([])
+const zones = ref<ZoneConfig[]>([])
+const saving = ref(false)
+
+async function handleAiGenerate() {
+  if (!prompt.value.trim()) return
+  aiLoading.value = true
+  try {
+    const result: AiGenerateResponse = await adminEventsApi.aiGenerate(prompt.value)
+    title.value = result.title
+    artist.value = result.artist || ''
+    venue.value = result.venue
+    dateTime.value = result.dateTime?.replace('T', 'T').slice(0, 16) || ''
+    totalSeats.value = result.totalSeats
+    trackPolicy.value = result.trackPolicy
+    grades.value = result.grades
+    zones.value = result.zones
+    aiGenerated.value = true
+
+    // ticketOpenAt 기본값: 공연 1시간 전
+    if (result.dateTime) {
+      const dt = new Date(result.dateTime)
+      dt.setHours(dt.getHours() - 1)
+      ticketOpenAt.value = dt.toISOString().slice(0, 16)
+      const close = new Date(result.dateTime)
+      close.setHours(close.getHours() + 2)
+      ticketCloseAt.value = close.toISOString().slice(0, 16)
+    }
+  } catch (e) {
+    console.error('AI 생성 실패', e)
+    alert('AI 생성에 실패했습니다. 다시 시도해주세요.')
+  } finally {
+    aiLoading.value = false
+  }
+}
+
+async function handleCreate() {
+  saving.value = true
+  try {
+    await adminEventsApi.create({
+      title: title.value,
+      artist: artist.value || null,
+      venue: venue.value,
+      dateTime: dateTime.value,
+      totalSeats: totalSeats.value,
+      ticketOpenAt: ticketOpenAt.value,
+      ticketCloseAt: ticketCloseAt.value,
+      trackPolicy: trackPolicy.value,
+      tenantId: tenantId.value,
+      grades: grades.value,
+      zones: zones.value,
+    })
+    router.push('/admin/events')
+  } catch (e) {
+    console.error('이벤트 생성 실패', e)
+    alert('이벤트 생성에 실패했습니다.')
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl px-4 lg:px-8 py-8">
+    <button
+      class="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-6 transition-colors"
+      @click="router.push('/admin/events')"
+    >
+      <ArrowLeft class="w-4 h-4" />
+      이벤트 목록
+    </button>
+
+    <h1 class="text-2xl font-display font-bold text-foreground mb-8">새 이벤트 생성</h1>
+
+    <!-- AI 생성 섹션 -->
+    <div class="bg-card border border-border rounded-xl p-6 mb-8">
+      <h2 class="text-lg font-display font-semibold text-foreground mb-4 flex items-center gap-2">
+        <Sparkles class="w-5 h-5 text-primary" />
+        AI 자동 생성
+      </h2>
+      <div class="flex gap-3">
+        <input
+          v-model="prompt"
+          type="text"
+          placeholder="예: 4월 올림픽홀 BTS 콘서트 2400석"
+          class="flex-1 h-11 px-4 rounded-lg bg-secondary border border-border text-foreground text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+          @keydown.enter="handleAiGenerate"
+        />
+        <button
+          class="inline-flex items-center gap-2 h-11 px-5 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50"
+          :disabled="aiLoading || !prompt.trim()"
+          @click="handleAiGenerate"
+        >
+          <Loader2 v-if="aiLoading" class="w-4 h-4 animate-spin" />
+          <Sparkles v-else class="w-4 h-4" />
+          AI 생성
+        </button>
+      </div>
+    </div>
+
+    <!-- 이벤트 폼 -->
+    <form v-if="aiGenerated" @submit.prevent="handleCreate" class="space-y-6">
+      <!-- 기본 정보 -->
+      <div class="bg-card border border-border rounded-xl p-6">
+        <h2 class="text-lg font-display font-semibold text-foreground mb-4">기본 정보</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">공연 제목</label>
+            <input v-model="title" type="text" required
+              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
+          </div>
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">아티스트</label>
+            <input v-model="artist" type="text"
+              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
+          </div>
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">공연장</label>
+            <input v-model="venue" type="text" required
+              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
+          </div>
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">총 좌석 수</label>
+            <input v-model.number="totalSeats" type="number" required
+              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
+          </div>
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">공연 일시</label>
+            <input v-model="dateTime" type="datetime-local" required
+              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
+          </div>
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">배정 방식</label>
+            <select v-model="trackPolicy"
+              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50">
+              <option value="LIVE_ONLY">선착순 (LIVE_ONLY)</option>
+              <option value="LOTTERY_ONLY">추첨 (LOTTERY_ONLY)</option>
+              <option value="DUAL_TRACK">듀얼 트랙 (DUAL_TRACK)</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <!-- 판매 설정 -->
+      <div class="bg-card border border-border rounded-xl p-6">
+        <h2 class="text-lg font-display font-semibold text-foreground mb-4">판매 설정</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">티켓 오픈 일시</label>
+            <input v-model="ticketOpenAt" type="datetime-local" required
+              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
+          </div>
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">티켓 마감 일시</label>
+            <input v-model="ticketCloseAt" type="datetime-local" required
+              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
+          </div>
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">테넌트 ID</label>
+            <input v-model="tenantId" type="text" required
+              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
+          </div>
+        </div>
+      </div>
+
+      <!-- 등급 구성 -->
+      <div class="bg-card border border-border rounded-xl p-6">
+        <h2 class="text-lg font-display font-semibold text-foreground mb-4">등급 구성</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border text-muted-foreground">
+                <th class="text-left py-2 pr-4">등급</th>
+                <th class="text-right py-2 pr-4">가격 (원)</th>
+                <th class="text-right py-2">좌석 수</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(g, i) in grades" :key="i" class="border-b border-border/50">
+                <td class="py-2 pr-4">
+                  <input v-model="g.grade" type="text"
+                    class="w-full h-8 px-2 rounded bg-secondary border border-border text-foreground text-sm" />
+                </td>
+                <td class="py-2 pr-4">
+                  <input v-model.number="g.price" type="number"
+                    class="w-full h-8 px-2 rounded bg-secondary border border-border text-foreground text-sm text-right" />
+                </td>
+                <td class="py-2">
+                  <input v-model.number="g.seatCount" type="number"
+                    class="w-full h-8 px-2 rounded bg-secondary border border-border text-foreground text-sm text-right" />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- 구역 구성 -->
+      <div class="bg-card border border-border rounded-xl p-6">
+        <h2 class="text-lg font-display font-semibold text-foreground mb-4">구역 구성</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border text-muted-foreground">
+                <th class="text-left py-2 pr-4">구역</th>
+                <th class="text-left py-2 pr-4">등급</th>
+                <th class="text-right py-2">좌석 수</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(z, i) in zones" :key="i" class="border-b border-border/50">
+                <td class="py-2 pr-4">
+                  <input v-model="z.zone" type="text"
+                    class="w-full h-8 px-2 rounded bg-secondary border border-border text-foreground text-sm" />
+                </td>
+                <td class="py-2 pr-4">
+                  <input v-model="z.grade" type="text"
+                    class="w-full h-8 px-2 rounded bg-secondary border border-border text-foreground text-sm" />
+                </td>
+                <td class="py-2">
+                  <input v-model.number="z.seatCount" type="number"
+                    class="w-full h-8 px-2 rounded bg-secondary border border-border text-foreground text-sm text-right" />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- 생성 버튼 -->
+      <div class="flex justify-end">
+        <button
+          type="submit"
+          :disabled="saving"
+          class="inline-flex items-center gap-2 h-11 px-6 rounded-full bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50"
+        >
+          <Loader2 v-if="saving" class="w-4 h-4 animate-spin" />
+          <Save v-else class="w-4 h-4" />
+          이벤트 생성
+        </button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/src/views/AdminEventsPage.vue
+++ b/src/views/AdminEventsPage.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { Plus, BarChart3, Trash2, Calendar, MapPin, Users } from 'lucide-vue-next'
+import { adminEventsApi, type AdminEventResponse } from '@/api/admin.events.api'
+
+const router = useRouter()
+const events = ref<AdminEventResponse[]>([])
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    events.value = await adminEventsApi.list()
+  } catch (e) {
+    console.error('이벤트 목록 조회 실패', e)
+  } finally {
+    loading.value = false
+  }
+})
+
+async function handleDelete(scheduleId: number) {
+  if (!confirm('이벤트를 삭제하시겠습니까?')) return
+  try {
+    await adminEventsApi.delete(scheduleId)
+    events.value = events.value.filter(e => e.scheduleId !== scheduleId)
+  } catch (e) {
+    console.error('삭제 실패', e)
+  }
+}
+
+const statusLabel: Record<string, string> = {
+  UPCOMING: '예정',
+  OPEN: '판매중',
+  CLOSED: '마감',
+  COMPLETED: '완료',
+}
+
+const statusColor: Record<string, string> = {
+  UPCOMING: 'bg-yellow-500/20 text-yellow-400',
+  OPEN: 'bg-green-500/20 text-green-400',
+  CLOSED: 'bg-red-500/20 text-red-400',
+  COMPLETED: 'bg-gray-500/20 text-gray-400',
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-7xl px-4 lg:px-8 py-8">
+    <div class="flex items-center justify-between mb-8">
+      <h1 class="text-2xl font-display font-bold text-foreground">이벤트 관리</h1>
+      <button
+        class="inline-flex items-center gap-2 h-10 px-5 rounded-full bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors"
+        @click="router.push('/admin/events/new')"
+      >
+        <Plus class="w-4 h-4" />
+        새 이벤트
+      </button>
+    </div>
+
+    <div v-if="loading" class="grid gap-4">
+      <div v-for="i in 3" :key="i" class="h-24 rounded-xl skeleton" />
+    </div>
+
+    <div v-else-if="events.length === 0" class="text-center py-20 text-muted-foreground">
+      아직 생성된 이벤트가 없습니다.
+    </div>
+
+    <div v-else class="grid gap-4">
+      <div
+        v-for="event in events"
+        :key="event.scheduleId"
+        class="bg-card border border-border rounded-xl p-5 flex items-center justify-between hover:border-primary/30 transition-colors"
+      >
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-3 mb-2">
+            <h3 class="text-lg font-display font-semibold text-foreground truncate">
+              {{ event.title }}
+            </h3>
+            <span
+              class="px-2.5 py-0.5 rounded-full text-xs font-medium"
+              :class="statusColor[event.status] || 'bg-gray-500/20 text-gray-400'"
+            >
+              {{ statusLabel[event.status] || event.status }}
+            </span>
+            <span class="px-2 py-0.5 rounded text-xs font-mono bg-secondary text-muted-foreground">
+              {{ event.trackPolicy }}
+            </span>
+          </div>
+          <div class="flex items-center gap-4 text-sm text-muted-foreground">
+            <span class="flex items-center gap-1">
+              <MapPin class="w-3.5 h-3.5" />
+              {{ event.venue }}
+            </span>
+            <span class="flex items-center gap-1">
+              <Calendar class="w-3.5 h-3.5" />
+              {{ new Date(event.dateTime).toLocaleDateString('ko-KR') }}
+            </span>
+            <span class="flex items-center gap-1">
+              <Users class="w-3.5 h-3.5" />
+              {{ event.totalSeats?.toLocaleString() }}석
+            </span>
+          </div>
+        </div>
+        <div class="flex items-center gap-2 ml-4">
+          <button
+            class="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            title="대시보드"
+            @click="router.push(`/admin/events/${event.scheduleId}`)"
+          >
+            <BarChart3 class="w-5 h-5" />
+          </button>
+          <button
+            class="p-2 rounded-lg text-muted-foreground hover:text-red-400 hover:bg-red-500/10 transition-colors"
+            title="삭제"
+            @click="handleDelete(event.scheduleId)"
+          >
+            <Trash2 class="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## 개요
어드민이 이벤트를 관리할 수 있는 프론트엔드 페이지를 추가합니다.

closes #6

## 변경 사항 (6 files changed, +690 / -0)

### 신규
| 파일 | 역할 |
|---|---|
| `admin.events.api.ts` | 어드민 이벤트 API 클라이언트 (CRUD + AI 생성 + 대시보드) |
| `AdminEventsPage.vue` | 이벤트 목록 (상태 뱃지, 삭제, 대시보드 링크) |
| `AdminEventCreatePage.vue` | AI 자연어 → 이벤트 구성 자동 생성 + 수정 폼 + 생성 |
| `AdminDashboardPage.vue` | 이벤트 상세 + 판매율 + 등급별 판매/잔여 현황 |

### 수정
| 파일 | 변경 내용 |
|---|---|
| `router/index.ts` | `/admin/events`, `/admin/events/new`, `/admin/events/:id` 라우트 추가 |
| `SiteHeader.vue` | Admin 네비게이션 링크 추가 |

## 페이지 플로우
1. Admin → 이벤트 목록 → "새 이벤트" 클릭
2. AI 프롬프트 입력 → AI가 등급/가격/구역 자동 생성
3. 어드민이 수정 → 판매 설정 (티켓 오픈/마감) 입력 → "이벤트 생성"
4. 목록으로 복귀, 대시보드에서 판매 현황 확인

## 타입 체크
`npx vue-tsc --noEmit` ✅ 통과