### PR TITLE
feat: #8 FE trackPolicy 분기 (ConcertDetail, QueuePage)

### DIFF
--- a/src/types/concert.ts
+++ b/src/types/concert.ts
@@ -10,6 +10,8 @@ export interface TicketGrade {
 
 export type ActiveTrack = 'lottery' | 'live' | 'none'
 
+export type TrackPolicy = 'LOTTERY_ONLY' | 'LIVE_ONLY' | 'DUAL_TRACK'
+
 export interface ConcertDate {
   id: string
   date: string // yyyy-MM-dd
@@ -17,6 +19,7 @@ export interface ConcertDate {
   venue: string
   available: boolean
   activeTrack?: ActiveTrack // 현재 열린 트랙 (없으면 둘 다 열림)
+  trackPolicy?: TrackPolicy // 배정 방식 (없으면 DUAL_TRACK)
 }
 
 export interface Concert {

--- a/src/views/ConcertDetailPage.vue
+++ b/src/views/ConcertDetailPage.vue
@@ -52,19 +52,23 @@ function goToLottery() {
     router.push({ name: 'login', query: { redirect: route.fullPath } })
     return
   }
-  router.push(`/lottery/${concert.value!.id}`)
+  router.push({ path: `/queue/${concert.value!.id}`, query: { track: 'lottery', trackPolicy: trackPolicy.value } })
 }
 
+const trackPolicy = computed(() => selectedDate.value?.trackPolicy ?? 'DUAL_TRACK')
+const showLottery = computed(() => trackPolicy.value !== 'LIVE_ONLY')
+const showLive = computed(() => trackPolicy.value !== 'LOTTERY_ONLY')
+
 const activeTrack = computed(() => selectedDate.value?.activeTrack ?? undefined)
-const isLotteryLocked = computed(() => activeTrack.value === 'live')
-const isLiveLocked = computed(() => activeTrack.value === 'lottery')
+const isLotteryLocked = computed(() => !showLottery.value || activeTrack.value === 'live')
+const isLiveLocked = computed(() => !showLive.value || activeTrack.value === 'lottery')
 
 function goToQueue() {
   if (!authStore.isLoggedIn) {
     router.push({ name: 'login', query: { redirect: route.fullPath } })
     return
   }
-  router.push(`/queue/${concert.value!.id}`)
+  router.push({ path: `/queue/${concert.value!.id}`, query: { trackPolicy: trackPolicy.value } })
 }
 </script>
 
@@ -263,14 +267,19 @@ function goToQueue() {
 
             <!-- 듀얼 트랙 선택 카드 -->
             <div class="rounded-xl border border-border bg-card p-6">
-              <h3 class="font-display text-lg font-bold text-foreground mb-2">예매 방식 선택</h3>
-              <p class="text-xs text-muted-foreground mb-5">
+              <h3 class="font-display text-lg font-bold text-foreground mb-2">
+                {{ trackPolicy === 'DUAL_TRACK' ? '예매 방식 선택' : '예매하기' }}
+              </h3>
+              <p v-if="trackPolicy === 'DUAL_TRACK'" class="text-xs text-muted-foreground mb-5">
                 원하는 예매 트랙을 선택하세요
+              </p>
+              <p v-else class="text-xs text-muted-foreground mb-5">
+                {{ trackPolicy === 'LOTTERY_ONLY' ? '추첨 예매로 진행됩니다' : '선착순 예매로 진행됩니다' }}
               </p>
 
               <!-- 로터리 트랙 -->
               <button
-                v-if="!isLotteryLocked"
+                v-if="showLottery && !isLotteryLocked"
                 :disabled="concert.saleStatus !== 'on-sale'"
                 class="w-full text-left p-4 rounded-xl border border-border bg-background hover:border-primary/40 hover:bg-primary/5 transition-all mb-3 group disabled:opacity-50 disabled:cursor-not-allowed"
                 @click="goToLottery"
@@ -292,7 +301,7 @@ function goToQueue() {
               </button>
               <!-- 로터리 트랙 (잠금) -->
               <div
-                v-else
+                v-else-if="showLottery"
                 class="w-full text-left p-4 rounded-xl border border-border bg-muted/30 mb-3 opacity-60 cursor-not-allowed"
               >
                 <div class="flex items-start gap-3">
@@ -310,7 +319,7 @@ function goToQueue() {
 
               <!-- 라이브 트랙 -->
               <button
-                v-if="!isLiveLocked"
+                v-if="showLive && !isLiveLocked"
                 :disabled="concert.saleStatus !== 'on-sale'"
                 class="w-full text-left p-4 rounded-xl border border-border bg-background hover:border-primary/40 hover:bg-primary/5 transition-all group disabled:opacity-50 disabled:cursor-not-allowed"
                 @click="goToQueue"
@@ -332,7 +341,7 @@ function goToQueue() {
               </button>
               <!-- 라이브 트랙 (잠금) -->
               <div
-                v-else
+                v-else-if="showLive"
                 class="w-full text-left p-4 rounded-xl border border-border bg-muted/30 opacity-60 cursor-not-allowed"
               >
                 <div class="flex items-start gap-3">

--- a/src/views/QueuePage.vue
+++ b/src/views/QueuePage.vue
@@ -12,7 +12,8 @@ const router = useRouter()
 const queueStore = useQueueStore()
 
 const concertId = route.params.concertId as string
-const track = (route.query.track as string) || 'live'
+const trackPolicy = (route.query.trackPolicy as string) || 'DUAL_TRACK'
+const track = trackPolicy === 'LOTTERY_ONLY' ? 'lottery' : (route.query.track as string) || 'live'
 const joining = ref(true)
 const cancelling = ref(false)
 


### PR DESCRIPTION
## 개요
trackPolicy에 따라 소비자 FE에서 트랙 선택 UI를 분기합니다.

closes #8

## 변경 사항 (3 files changed, +24 / -11)

### 수정
| 파일 | 변경 내용 |
|---|---|
| `concert.ts` | `TrackPolicy` 타입 + `ConcertDate.trackPolicy` 필드 추가 |
| `ConcertDetailPage.vue` | trackPolicy에 따라 트랙 버튼 표시/숨김 + 섹션 헤더 분기 |
| `QueuePage.vue` | trackPolicy 쿼리 파라미터 기반 리다이렉트 대상 결정 |

## 동작 방식
| trackPolicy | 트랙 선택 UI | 예매 플로우 |
|---|---|---|
| `LOTTERY_ONLY` | 로터리만 표시 | "추첨 예매로 진행됩니다" → Queue → Lottery |
| `LIVE_ONLY` | 라이브만 표시 | "선착순 예매로 진행됩니다" → Queue → Seats |
| `DUAL_TRACK` | 둘 다 표시 (기존) | "예매 방식 선택" → 트랙 선택 → Queue → 해당 페이지 |

## 하위 호환
- `trackPolicy`가 없는 경우 `DUAL_TRACK`으로 기본 동작 (기존 호환)

## 타입 체크
`npx vue-tsc --noEmit` ✅ 통과