### PR TITLE
feat: #10 역할 기반 회원가입/로그인/라우팅 분기

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,4 +1,4 @@
-import type { AuthResponse, AuthApiResponse, LoginRequest, SignupRequest } from '@/types/auth'
+import type { AuthResponse, AuthApiResponse, LoginRequest, SignupRequest, UserRole } from '@/types/auth'
 import client from './client'
 
 const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
@@ -11,11 +11,12 @@ function mapAuthResponse(raw: AuthApiResponse, name?: string, phone?: string): A
       email: raw.email,
       name: name ?? raw.name ?? '',
       phone: phone ?? '',
+      role: (raw.role as UserRole) ?? 'CONSUMER',
     },
   }
 }
 
-function mockAuthResponse(email: string, name?: string, phone?: string): AuthResponse {
+function mockAuthResponse(email: string, name?: string, phone?: string, role?: UserRole): AuthResponse {
   return {
     accessToken: 'mock-jwt-token-' + Date.now(),
     user: {
@@ -23,6 +24,7 @@ function mockAuthResponse(email: string, name?: string, phone?: string): AuthRes
       email,
       name: name ?? email.split('@')[0] ?? 'User',
       phone: phone ?? '010-0000-0000',
+      role: role ?? 'CONSUMER',
     },
   }
 }
@@ -31,7 +33,7 @@ export const authApi = {
   async signup(data: SignupRequest): Promise<AuthResponse> {
     if (USE_MOCK) {
       await new Promise((r) => setTimeout(r, 500))
-      return mockAuthResponse(data.email, data.name, data.phone)
+      return mockAuthResponse(data.email, data.name, data.phone, data.role)
     }
     const raw = (await client.post<AuthApiResponse>('/v1/auth/signup', data)).data
     return mapAuthResponse(raw, data.name, data.phone)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -69,19 +69,19 @@ const router = createRouter({
       path: '/admin/events',
       name: 'admin-events',
       component: () => import('@/views/AdminEventsPage.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresOrganizer: true },
     },
     {
       path: '/admin/events/new',
       name: 'admin-event-create',
       component: () => import('@/views/AdminEventCreatePage.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresOrganizer: true },
     },
     {
       path: '/admin/events/:id',
       name: 'admin-dashboard',
       component: () => import('@/views/AdminDashboardPage.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresOrganizer: true },
     },
     {
       path: '/:pathMatch(.*)*',
@@ -94,6 +94,18 @@ const router = createRouter({
 router.beforeEach((to) => {
   if (to.meta.requiresAuth && !localStorage.getItem('access_token')) {
     return { name: 'login', query: { redirect: to.fullPath } }
+  }
+
+  if (to.meta.requiresOrganizer) {
+    try {
+      const raw = localStorage.getItem('user')
+      const user = raw ? JSON.parse(raw) : null
+      if (user?.role !== 'ORGANIZER') {
+        return { name: 'home' }
+      }
+    } catch {
+      return { name: 'home' }
+    }
   }
 })
 

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import type { User } from '@/types/auth'
+import type { User, UserRole } from '@/types/auth'
 import { authApi } from '@/api/auth.api'
 
 function loadUser(): User | null {
@@ -19,9 +19,10 @@ export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem('access_token'))
 
   const isLoggedIn = computed(() => !!token.value)
+  const isOrganizer = computed(() => user.value?.role === 'ORGANIZER')
 
-  async function signup(email: string, password: string, name: string, phone: string) {
-    const res = await authApi.signup({ email, password, name, phone })
+  async function signup(email: string, password: string, name: string, phone: string, role: UserRole) {
+    const res = await authApi.signup({ email, password, name, phone, role })
     token.value = res.accessToken
     user.value = res.user
     localStorage.setItem('access_token', res.accessToken)
@@ -49,5 +50,5 @@ export const useAuthStore = defineStore('auth', () => {
     router.push('/login')
   }
 
-  return { user, token, isLoggedIn, signup, login, logout }
+  return { user, token, isLoggedIn, isOrganizer, signup, login, logout }
 })

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,8 +1,11 @@
+export type UserRole = 'CONSUMER' | 'ORGANIZER'
+
 export interface User {
   id: string
   email: string
   name: string
   phone: string
+  role: UserRole
 }
 
 export interface SignupRequest {
@@ -10,6 +13,7 @@ export interface SignupRequest {
   password: string
   name: string
   phone: string
+  role: UserRole
 }
 
 export interface LoginRequest {
@@ -27,5 +31,6 @@ export interface AuthApiResponse {
   userId: number
   email: string
   name: string
+  role: string
   token: string
 }

--- a/src/views/LoginPage.vue
+++ b/src/views/LoginPage.vue
@@ -18,7 +18,7 @@ async function handleSubmit() {
   loading.value = true
   try {
     await authStore.login(email.value, password.value)
-    const redirect = (route.query.redirect as string) || '/concerts'
+    const redirect = (route.query.redirect as string) || (authStore.isOrganizer ? '/admin/events' : '/concerts')
     router.push(redirect)
   } catch {
     error.value = '로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.'

--- a/src/views/SignupPage.vue
+++ b/src/views/SignupPage.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { Mail, Lock, UserIcon, Phone, Loader2 } from 'lucide-vue-next'
+import { Mail, Lock, UserIcon, Phone, Loader2, Ticket, Megaphone } from 'lucide-vue-next'
 import { useAuthStore } from '@/stores/auth.store'
+import type { UserRole } from '@/types/auth'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -12,6 +13,7 @@ const email = ref('')
 const phone = ref('')
 const password = ref('')
 const passwordConfirm = ref('')
+const role = ref<UserRole>('CONSUMER')
 const loading = ref(false)
 const error = ref('')
 
@@ -42,8 +44,8 @@ async function handleSubmit() {
 
   loading.value = true
   try {
-    await authStore.signup(email.value, password.value, name.value, phone.value)
-    router.push('/concerts')
+    await authStore.signup(email.value, password.value, name.value, phone.value, role.value)
+    router.push(role.value === 'ORGANIZER' ? '/admin/events' : '/concerts')
   } catch {
     error.value = '회원가입에 실패했습니다. 다시 시도해주세요.'
   } finally {
@@ -85,6 +87,41 @@ async function handleSubmit() {
             class="rounded-lg bg-destructive/10 lg:bg-red-50 border border-destructive/30 lg:border-red-200 px-4 py-3 text-sm text-destructive lg:text-red-600"
           >
             {{ error }}
+          </div>
+
+          <!-- 역할 선택 -->
+          <div class="space-y-2">
+            <label class="text-sm font-medium text-foreground lg:text-gray-700">가입 유형</label>
+            <div class="grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                @click="role = 'CONSUMER'"
+                :class="[
+                  'flex flex-col items-center gap-2 p-4 rounded-lg border-2 transition-all',
+                  role === 'CONSUMER'
+                    ? 'border-primary bg-primary/5 lg:bg-primary/10'
+                    : 'border-input lg:border-gray-200 hover:border-primary/50'
+                ]"
+              >
+                <Ticket class="w-5 h-5" :class="role === 'CONSUMER' ? 'text-primary' : 'text-muted-foreground lg:text-gray-400'" />
+                <span class="text-sm font-medium" :class="role === 'CONSUMER' ? 'text-primary' : 'text-foreground lg:text-gray-700'">티켓 구매자</span>
+                <span class="text-xs text-muted-foreground lg:text-gray-400">공연 예매</span>
+              </button>
+              <button
+                type="button"
+                @click="role = 'ORGANIZER'"
+                :class="[
+                  'flex flex-col items-center gap-2 p-4 rounded-lg border-2 transition-all',
+                  role === 'ORGANIZER'
+                    ? 'border-primary bg-primary/5 lg:bg-primary/10'
+                    : 'border-input lg:border-gray-200 hover:border-primary/50'
+                ]"
+              >
+                <Megaphone class="w-5 h-5" :class="role === 'ORGANIZER' ? 'text-primary' : 'text-muted-foreground lg:text-gray-400'" />
+                <span class="text-sm font-medium" :class="role === 'ORGANIZER' ? 'text-primary' : 'text-foreground lg:text-gray-700'">이벤트 주최자</span>
+                <span class="text-xs text-muted-foreground lg:text-gray-400">공연 등록 / 관리</span>
+              </button>
+            </div>
           </div>
 
           <div class="space-y-2">


### PR DESCRIPTION
## 개요
회원가입 시 역할(주최자/소비자) 선택 UI를 추가하고, 로그인 후 역할에 따라 라우팅을 분기한다.

closes #10

## 변경 사항
| 파일 | 변경 |
|---|---|
| `types/auth.ts` | `UserRole` 타입 추가, User/SignupRequest/AuthApiResponse에 role 필드 |
| `auth.api.ts` | role 매핑 반영 |
| `auth.store.ts` | `isOrganizer` computed, signup에 role 파라미터 추가 |
| `SignupPage.vue` | 역할 선택 UI (티켓 구매자/이벤트 주최자) |
| `LoginPage.vue` | 역할별 리다이렉트 (ORGANIZER → `/admin/events`) |
| `router/index.ts` | admin 라우트 `requiresOrganizer` 가드 추가 |

## 타입/빌드 검증
- `npx vue-tsc --noEmit` ✅ 에러 없음
- `npx vite build` ✅ 빌드 성공