### PR TITLE
feat: #12 멀티 테넌시 FE 연동

### DIFF
--- a/src/api/admin.events.api.ts
+++ b/src/api/admin.events.api.ts
@@ -32,7 +32,6 @@ export interface AdminEventCreateRequest {
   ticketOpenAt: string
   ticketCloseAt: string
   trackPolicy: string
-  tenantId: string
   grades: GradeConfig[]
   zones: ZoneConfig[]
 }

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -12,6 +12,7 @@ function mapAuthResponse(raw: AuthApiResponse, name?: string, phone?: string): A
       name: name ?? raw.name ?? '',
       phone: phone ?? '',
       role: (raw.role as UserRole) ?? 'CONSUMER',
+      tenantId: raw.tenantId,
     },
   }
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -18,6 +18,9 @@ client.interceptors.request.use((config) => {
       if (user.id) {
         config.headers['X-User-Id'] = String(user.id)
       }
+      if (user.tenantId) {
+        config.headers['X-Tenant-Id'] = user.tenantId
+      }
     } catch {
       // ignore malformed JSON
     }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -6,6 +6,7 @@ export interface User {
   name: string
   phone: string
   role: UserRole
+  tenantId?: string
 }
 
 export interface SignupRequest {
@@ -32,5 +33,6 @@ export interface AuthApiResponse {
   email: string
   name: string
   role: string
+  tenantId?: string
   token: string
 }

--- a/src/views/AdminEventCreatePage.vue
+++ b/src/views/AdminEventCreatePage.vue
@@ -20,7 +20,6 @@ const totalSeats = ref(0)
 const trackPolicy = ref('DUAL_TRACK')
 const ticketOpenAt = ref('')
 const ticketCloseAt = ref('')
-const tenantId = ref('default')
 const grades = ref<GradeConfig[]>([])
 const zones = ref<ZoneConfig[]>([])
 const saving = ref(false)
@@ -69,7 +68,6 @@ async function handleCreate() {
       ticketOpenAt: ticketOpenAt.value,
       ticketCloseAt: ticketCloseAt.value,
       trackPolicy: trackPolicy.value,
-      tenantId: tenantId.value,
       grades: grades.value,
       zones: zones.value,
     })
@@ -176,11 +174,6 @@ async function handleCreate() {
           <div>
             <label class="block text-sm text-muted-foreground mb-1.5">티켓 마감 일시</label>
             <input v-model="ticketCloseAt" type="datetime-local" required
-              class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
-          </div>
-          <div>
-            <label class="block text-sm text-muted-foreground mb-1.5">테넌트 ID</label>
-            <input v-model="tenantId" type="text" required
               class="w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/50" />
           </div>
         </div>


### PR DESCRIPTION
## 개요
로그인 시 tenantId를 저장하고, admin API 요청에 X-Tenant-Id 헤더를 자동 첨부한다.

closes #12

## 변경 사항
| 파일 | 변경 |
|---|---|
| `types/auth.ts` | User/AuthApiResponse에 tenantId 추가 |
| `auth.api.ts` | mapAuthResponse에 tenantId 매핑 |
| `client.ts` | X-Tenant-Id 헤더 자동 첨부 |
| `admin.events.api.ts` | AdminEventCreateRequest에서 tenantId 제거 |
| `AdminEventCreatePage.vue` | tenantId 입력 필드/ref/전송 제거 |

## 타입/빌드 검증
- `npx vue-tsc --noEmit` ✅ 에러 없음
- `npx vite build` ✅ 빌드 성공