### PR TITLE
feat: #16 AI 운영 인사이트 대시보드 UI

### DIFF
--- a/src/api/admin.events.api.ts
+++ b/src/api/admin.events.api.ts
@@ -70,6 +70,20 @@ export interface GradeStat {
   availableSeats: number
 }
 
+export interface RecommendedAction {
+  type: 'PRICE_ADJUST' | 'TRACK_CHANGE' | 'CAPACITY_WARNING' | 'MARKETING'
+  title: string
+  description: string
+  urgency: 'LOW' | 'MEDIUM' | 'HIGH'
+}
+
+export interface AdminInsightResponse {
+  scheduleId: number
+  riskLevel: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL'
+  insights: string[]
+  actions: RecommendedAction[]
+}
+
 export interface AdminDashboardResponse {
   scheduleId: number
   title: string
@@ -112,6 +126,11 @@ export const adminEventsApi = {
 
   async dashboard(scheduleId: number): Promise<AdminDashboardResponse> {
     const { data } = await client.get(`/v1/admin/events/${scheduleId}/dashboard`)
+    return data
+  },
+
+  async getInsights(scheduleId: number): Promise<AdminInsightResponse> {
+    const { data } = await client.get(`/v1/admin/events/${scheduleId}/insights`)
     return data
   },
 

--- a/src/views/AdminDashboardPage.vue
+++ b/src/views/AdminDashboardPage.vue
@@ -1,8 +1,17 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ArrowLeft, Calendar, MapPin, Users, TrendingUp, Ticket } from 'lucide-vue-next'
-import { adminEventsApi, type AdminEventResponse, type AdminDashboardResponse } from '@/api/admin.events.api'
+import {
+  ArrowLeft, Calendar, MapPin, Users, TrendingUp, Ticket,
+  Brain, RefreshCw, AlertTriangle, Lightbulb, Zap, ShieldAlert,
+  DollarSign, Shuffle, AlertCircle, Megaphone,
+} from 'lucide-vue-next'
+import {
+  adminEventsApi,
+  type AdminEventResponse,
+  type AdminDashboardResponse,
+  type AdminInsightResponse,
+} from '@/api/admin.events.api'
 
 const route = useRoute()
 const router = useRouter()
@@ -10,7 +19,9 @@ const scheduleId = Number(route.params.id)
 
 const event = ref<AdminEventResponse | null>(null)
 const dashboard = ref<AdminDashboardResponse | null>(null)
+const insight = ref<AdminInsightResponse | null>(null)
 const loading = ref(true)
+const insightLoading = ref(false)
 
 onMounted(async () => {
   try {
@@ -20,12 +31,24 @@ onMounted(async () => {
     ])
     event.value = e
     dashboard.value = d
+    loadInsights()
   } catch (e) {
     console.error('조회 실패', e)
   } finally {
     loading.value = false
   }
 })
+
+async function loadInsights() {
+  insightLoading.value = true
+  try {
+    insight.value = await adminEventsApi.getInsights(scheduleId)
+  } catch (e) {
+    console.error('인사이트 조회 실패', e)
+  } finally {
+    insightLoading.value = false
+  }
+}
 
 const soldPercent = computed(() => {
   if (!dashboard.value || !dashboard.value.totalSeats) return 0
@@ -44,6 +67,26 @@ const statusColor: Record<string, string> = {
   OPEN: 'bg-green-500/15 text-green-600',
   CLOSED: 'bg-red-500/15 text-red-600',
   COMPLETED: 'bg-gray-500/15 text-gray-600',
+}
+
+const riskConfig: Record<string, { label: string; cls: string; icon: typeof ShieldAlert }> = {
+  LOW: { label: '안정', cls: 'bg-green-500/15 text-green-600 border-green-500/30', icon: ShieldAlert },
+  MEDIUM: { label: '주의', cls: 'bg-yellow-500/15 text-yellow-600 border-yellow-500/30', icon: AlertTriangle },
+  HIGH: { label: '경고', cls: 'bg-orange-500/15 text-orange-600 border-orange-500/30', icon: AlertCircle },
+  CRITICAL: { label: '위험', cls: 'bg-red-500/15 text-red-600 border-red-500/30', icon: Zap },
+}
+
+const actionIcons: Record<string, typeof DollarSign> = {
+  PRICE_ADJUST: DollarSign,
+  TRACK_CHANGE: Shuffle,
+  CAPACITY_WARNING: AlertTriangle,
+  MARKETING: Megaphone,
+}
+
+const urgencyColor: Record<string, string> = {
+  LOW: 'bg-blue-500/15 text-blue-600',
+  MEDIUM: 'bg-yellow-500/15 text-yellow-600',
+  HIGH: 'bg-red-500/15 text-red-600',
 }
 </script>
 
@@ -107,7 +150,7 @@ const statusColor: Record<string, string> = {
           <div class="flex items-center gap-2 text-muted-foreground text-sm mb-2">
             <TrendingUp class="w-4 h-4" /> 판매량
           </div>
-          <p class="text-2xl font-display font-bold text-green-400">
+          <p class="text-2xl font-display font-bold text-green-600">
             {{ dashboard.soldSeats.toLocaleString() }}
           </p>
         </div>
@@ -135,6 +178,87 @@ const statusColor: Record<string, string> = {
         </div>
       </div>
 
+      <!-- AI 운영 인사이트 -->
+      <div class="bg-card border border-border rounded-xl p-6 mb-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-display font-semibold text-foreground flex items-center gap-2">
+            <Brain class="w-5 h-5 text-primary" />
+            AI 운영 인사이트
+          </h2>
+          <div class="flex items-center gap-3">
+            <span
+              v-if="insight"
+              class="px-3 py-1 rounded-full text-xs font-semibold border"
+              :class="riskConfig[insight.riskLevel]?.cls"
+            >
+              {{ riskConfig[insight.riskLevel]?.label || insight.riskLevel }}
+            </span>
+            <button
+              class="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors disabled:opacity-50"
+              :disabled="insightLoading"
+              title="분석 갱신"
+              @click="loadInsights"
+            >
+              <RefreshCw class="w-4 h-4" :class="insightLoading ? 'animate-spin' : ''" />
+            </button>
+          </div>
+        </div>
+
+        <!-- 로딩 -->
+        <div v-if="insightLoading && !insight" class="space-y-3">
+          <div class="h-5 w-3/4 skeleton rounded" />
+          <div class="h-5 w-1/2 skeleton rounded" />
+          <div class="h-5 w-2/3 skeleton rounded" />
+        </div>
+
+        <!-- 인사이트 내용 -->
+        <template v-else-if="insight">
+          <!-- 핵심 분석 -->
+          <div class="space-y-2 mb-5">
+            <div
+              v-for="(text, i) in insight.insights"
+              :key="i"
+              class="flex items-start gap-2.5 text-sm text-foreground"
+            >
+              <Lightbulb class="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
+              <span>{{ text }}</span>
+            </div>
+          </div>
+
+          <!-- 추천 액션 -->
+          <div v-if="insight.actions.length" class="border-t border-border pt-4">
+            <h3 class="text-sm font-semibold text-muted-foreground mb-3">추천 액션</h3>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div
+                v-for="(action, i) in insight.actions"
+                :key="i"
+                class="bg-secondary/50 border border-border rounded-lg p-4"
+              >
+                <div class="flex items-center gap-2 mb-2">
+                  <component
+                    :is="actionIcons[action.type] || Lightbulb"
+                    class="w-4 h-4 text-primary"
+                  />
+                  <span class="text-sm font-semibold text-foreground">{{ action.title }}</span>
+                  <span
+                    class="ml-auto px-2 py-0.5 rounded-full text-[10px] font-semibold"
+                    :class="urgencyColor[action.urgency]"
+                  >
+                    {{ action.urgency }}
+                  </span>
+                </div>
+                <p class="text-xs text-muted-foreground leading-relaxed">{{ action.description }}</p>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <!-- 실패 -->
+        <div v-else class="text-sm text-muted-foreground text-center py-4">
+          인사이트를 불러올 수 없습니다. 다시 시도해주세요.
+        </div>
+      </div>
+
       <!-- 등급별 현황 -->
       <div class="bg-card border border-border rounded-xl p-6">
         <h2 class="text-lg font-display font-semibold text-foreground mb-4">등급별 현황</h2>
@@ -157,7 +281,7 @@ const statusColor: Record<string, string> = {
               >
                 <td class="py-3 pr-4 font-medium text-foreground">{{ stat.grade }}</td>
                 <td class="py-3 pr-4 text-right text-muted-foreground">{{ stat.totalSeats.toLocaleString() }}</td>
-                <td class="py-3 pr-4 text-right text-green-400">{{ stat.soldSeats.toLocaleString() }}</td>
+                <td class="py-3 pr-4 text-right text-green-600">{{ stat.soldSeats.toLocaleString() }}</td>
                 <td class="py-3 pr-4 text-right text-foreground">{{ stat.availableSeats.toLocaleString() }}</td>
                 <td class="py-3 text-right">
                   <span class="text-primary font-medium">


### PR DESCRIPTION
## 개요
event-service의 AI 인사이트 API를 활용하여 ORGANIZER용 운영 인사이트 대시보드 UI를 추가합니다.

closes #16

## 변경 사항
| 파일 | 변경 내용 |
|------|----------|
| `admin.events.api.ts` | `AdminInsightResponse`, `RecommendedAction` 타입 + `getInsights()` 메서드 |
| `AdminDashboardPage.vue` | AI 인사이트 섹션 통합 (위험도 뱃지, 분석 목록, 추천 액션 카드, 갱신 버튼) |

## UI 구성
- **위험도 레벨**: LOW(안정/초록) → MEDIUM(주의/노랑) → HIGH(경고/주황) → CRITICAL(위험/빨강)
- **핵심 분석**: Lightbulb 아이콘 + 자연어 인사이트 3~5개
- **추천 액션**: 유형별 아이콘(가격조정/배정변경/용량경고/마케팅) + 긴급도 뱃지
- **갱신 버튼**: 클릭 시 OpenAI 재분석 (로딩 스피너)

## 컴파일/타입 검증
- `vue-tsc -b && vite build` 성공