### PR TITLE
feat: #18 카테고리 필터 탭 + AI 자동 분류 연동

### DIFF
--- a/src/api/admin.events.api.ts
+++ b/src/api/admin.events.api.ts
@@ -19,6 +19,7 @@ export interface AiGenerateResponse {
   dateTime: string
   totalSeats: number
   trackPolicy: string
+  category: string
   grades: GradeConfig[]
   zones: ZoneConfig[]
 }
@@ -34,6 +35,7 @@ export interface AdminEventCreateRequest {
   trackPolicy: string
   imageUrl: string | null
   organizerName: string | null
+  category: string | null
   grades: GradeConfig[]
   zones: ZoneConfig[]
 }

--- a/src/components/concert/ConcertCard.vue
+++ b/src/components/concert/ConcertCard.vue
@@ -17,6 +17,16 @@ const formattedDate = computed(() => {
 
 const lowestPrice = computed(() => Math.min(...props.concert.grades.map((g) => g.price)))
 
+const categoryLabel: Record<string, string> = {
+  CONCERT: '콘서트',
+  SPORTS: '스포츠',
+  MUSICAL: '뮤지컬',
+  FANMEETING: '팬미팅',
+  FESTIVAL: '페스티벌',
+  EXHIBITION: '전시',
+  OTHER: '기타',
+}
+
 const statusBadge = computed(() => {
   switch (props.concert.saleStatus) {
     case 'on-sale':
@@ -42,12 +52,18 @@ const statusBadge = computed(() => {
           class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
         />
         <div class="absolute inset-0 bg-gradient-to-t from-card via-transparent to-transparent" />
-        <div class="absolute top-3 left-3">
+        <div class="absolute top-3 left-3 flex gap-1.5">
           <span
             :class="statusBadge.class"
             class="px-2.5 py-0.5 text-xs font-semibold rounded-full border"
           >
             {{ statusBadge.text }}
+          </span>
+          <span
+            v-if="concert.category && concert.category !== 'OTHER'"
+            class="px-2.5 py-0.5 text-xs font-semibold rounded-full bg-background/80 text-foreground backdrop-blur-sm border border-border/50"
+          >
+            {{ categoryLabel[concert.category] || concert.category }}
           </span>
         </div>
       </div>

--- a/src/types/concert.ts
+++ b/src/types/concert.ts
@@ -31,7 +31,7 @@ export interface Concert {
   venue: string
   image: string
   organizerName?: string
-  category?: string
+  category?: 'CONCERT' | 'SPORTS' | 'MUSICAL' | 'FANMEETING' | 'FESTIVAL' | 'EXHIBITION' | 'OTHER'
   subtitle?: string
   description?: string
   tags?: string[]

--- a/src/views/AdminEventCreatePage.vue
+++ b/src/views/AdminEventCreatePage.vue
@@ -40,6 +40,7 @@ const venue = ref('')
 const dateTime = ref('')
 const totalSeats = ref(0)
 const trackPolicy = ref('DUAL_TRACK')
+const category = ref('CONCERT')
 const ticketOpenAt = ref('')
 const ticketCloseAt = ref('')
 const grades = ref<GradeConfig[]>([])
@@ -149,6 +150,7 @@ async function handleAiGenerate() {
     dateTime.value = result.dateTime?.replace('T', 'T').slice(0, 16) || ''
     totalSeats.value = result.totalSeats
     trackPolicy.value = result.trackPolicy
+    category.value = result.category || 'OTHER'
     grades.value = result.grades
     zones.value = result.zones
     formReady.value = true
@@ -184,6 +186,7 @@ async function handleCreate() {
       trackPolicy: trackPolicy.value,
       imageUrl: imageUrl.value,
       organizerName: authStore.user?.name ?? null,
+      category: category.value,
       grades: grades.value,
       zones: zones.value,
     })
@@ -360,6 +363,18 @@ const cellInputCls =
               <option value="LIVE_ONLY">선착순 (LIVE_ONLY)</option>
               <option value="LOTTERY_ONLY">추첨 (LOTTERY_ONLY)</option>
               <option value="DUAL_TRACK">듀얼 트랙 (DUAL_TRACK)</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm text-muted-foreground mb-1.5">카테고리</label>
+            <select v-model="category" :class="inputCls">
+              <option value="CONCERT">콘서트</option>
+              <option value="SPORTS">스포츠</option>
+              <option value="MUSICAL">뮤지컬/연극</option>
+              <option value="FANMEETING">팬미팅</option>
+              <option value="FESTIVAL">페스티벌</option>
+              <option value="EXHIBITION">전시</option>
+              <option value="OTHER">기타</option>
             </select>
           </div>
         </div>

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -9,7 +9,23 @@ import { ArrowRight, CalendarDays, ChevronLeft, ChevronRight } from 'lucide-vue-
 const concerts = ref<Concert[]>([])
 const loading = ref(true)
 const current = ref(0)
+const activeCategory = ref('ALL')
 let timer = 0
+
+const categories = [
+  { key: 'ALL', label: '전체' },
+  { key: 'CONCERT', label: '콘서트' },
+  { key: 'SPORTS', label: '스포츠' },
+  { key: 'MUSICAL', label: '뮤지컬' },
+  { key: 'FANMEETING', label: '팬미팅' },
+  { key: 'FESTIVAL', label: '페스티벌' },
+  { key: 'EXHIBITION', label: '전시' },
+]
+
+const filteredConcerts = computed(() => {
+  if (activeCategory.value === 'ALL') return concerts.value
+  return concerts.value.filter((c) => c.category === activeCategory.value)
+})
 
 const heroSlides = computed(() => concerts.value)
 
@@ -199,8 +215,27 @@ function formatDate(d: string) {
         </template>
       </section>
 
+      <!-- 카테고리 필터 -->
+      <section class="px-4 lg:px-8 mx-auto max-w-7xl pt-10 pb-4">
+        <div class="flex gap-2 overflow-x-auto pb-2">
+          <button
+            v-for="cat in categories"
+            :key="cat.key"
+            class="px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-all"
+            :class="
+              activeCategory === cat.key
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'bg-secondary text-muted-foreground hover:text-foreground'
+            "
+            @click="activeCategory = cat.key"
+          >
+            {{ cat.label }}
+          </button>
+        </div>
+      </section>
+
       <!-- 콘서트 그리드 -->
-      <ConcertsGrid :concerts="concerts" />
+      <ConcertsGrid :concerts="filteredConcerts" />
     </template>
   </div>
 </template>


### PR DESCRIPTION
## 개요
소비자 홈페이지에 카테고리 필터 탭을 추가하고, 이벤트 생성 시 AI 자동 카테고리 분류를 연동합니다.

closes #18

## 변경 사항
| 파일 | 변경 내용 |
|------|----------|
| `concert.ts` | Concert 타입에 category 필드 추가 |
| `admin.events.api.ts` | AiGenerateResponse/AdminEventCreateRequest에 category 추가 |
| `AdminEventCreatePage.vue` | AI 생성 시 category 반영 + 직접 입력 시 카테고리 드롭다운 |
| `HomePage.vue` | 카테고리 필터 탭 (전체/콘서트/스포츠/뮤지컬/팬미팅/페스티벌/전시) |
| `ConcertCard.vue` | 카테고리 뱃지 (이미지 좌상단, 상태 뱃지 옆) |

## 컴파일/타입 검증
- `vue-tsc -b && vite build` 성공