### PR TITLE
feat: k8s 매니페스트 운영 설정 반영 (#30)

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -5,10 +5,12 @@ metadata:
   namespace: opentraum
   labels:
     app: web
+    app.kubernetes.io/name: web
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: web
 spec:
   replicas: 2
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: web
@@ -16,16 +18,27 @@ spec:
     metadata:
       labels:
         app: web
+        app.kubernetes.io/name: web
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: web
     spec:
+      terminationGracePeriodSeconds: 30
+      priorityClassName: opentraum-low
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: web
       imagePullSecrets:
         - name: harbor-secret
       containers:
         - name: web
           image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-web:latest
+          imagePullPolicy: Always
           ports:
-            - containerPort: 3000
+            - containerPort: 80
               protocol: TCP
           resources:
             requests:
@@ -37,7 +50,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 3000
+              port: 80
             initialDelaySeconds: 30
             periodSeconds: 15
             timeoutSeconds: 5
@@ -45,7 +58,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 3000
+              port: 80
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5

--- a/k8s/service.yml
+++ b/k8s/service.yml
@@ -11,5 +11,5 @@ spec:
     app: web
   ports:
     - port: 80
-      targetPort: 3000
+      targetPort: 80
   type: ClusterIP


### PR DESCRIPTION
## Summary
- 컨테이너 포트 3000 → 80 (Nginx 기본 포트로 통일)
- `priorityClassName: opentraum-low` 추가
- topologySpreadConstraints 추가
- terminationGracePeriodSeconds 30
- `imagePullPolicy: Always` 추가
- liveness/readiness Probe port 3000 → 80
- service `targetPort` 3000 → 80
- 라벨 `app.kubernetes.io/name`, `revisionHistoryLimit: 2` 추가

## Why
OpenTraum-Infra `k8s-manual/web/` 의 운영 설정을 본 레포 `k8s/` 로 이관해 ArgoCD GitOps 자동 배포 전환 준비를 완료합니다. Nginx 기본 포트 80 으로 통일합니다.

## Test plan
- [ ] ArgoCD sync 정상 확인
- [ ] web Pod 가 80 포트로 정상 응답 확인
- [ ] gateway -> web 라우팅 정상 확인

Closes #30