### PR TITLE
fix: Service targetPort 3000 → 80 (Web 502)

### DIFF
--- a/k8s/service.yml
+++ b/k8s/service.yml
@@ -11,5 +11,5 @@ spec:
     app: web
   ports:
     - port: 80
-      targetPort: 3000
+      targetPort: 80
   type: ClusterIP


### PR DESCRIPTION
## 배경 / 문제

Ingress(\`skala3-cloud1-team8.cloud.skala-ai.com\`) / 접근 시 nginx 502 Bad Gateway.

## 원인

- Web 컨테이너 이미지: nginx prod 빌드 (80 listen)
- \`k8s/service.yml\` \`targetPort: 3000\` (dev/Vite 포트, 실 listen 포트와 불일치)

## 수정

- \`service.yml\`: \`targetPort: 3000\` → \`targetPort: 80\`

## 검증

service patch + ingress controller reload 후 \`https://...\` 200, HTML 정상.

이슈: #33