### PR TITLE
chore: #41 Pod 자원 재산정 + replica 1로 변경

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: web
 spec:
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -40,11 +40,11 @@ spec:
               protocol: TCP
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "100m"
+              memory: "64Mi"
+              cpu: "50m"
             limits:
-              memory: "256Mi"
-              cpu: "300m"
+              memory: "64Mi"
+              cpu: "50m"
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Closes #41

## 변경

### `k8s/deployment.yml`
- `spec.replicas`: `2` → `1`
- `resources.requests.cpu`: `100m` → `50m`
- `resources.requests.memory`: `128Mi` → `64Mi`
- `resources.limits.cpu`: `300m` → `50m`
- `resources.limits.memory`: `256Mi` → `64Mi`

## 영향
- replica: 2 → 1 (다른 서비스와 일관성)
- QoS: `Burstable` → `Guaranteed` (가장 늦게 evict)
- CPU request 합계 절감: -150m (200m → 50m)
- Memory request 합계 절감: -192Mi (256Mi → 64Mi)
- ArgoCD 자동 sync 시 RollingUpdate 로 Pod 교체 (`maxSurge`, `maxUnavailable` 정책 적용)
