### PR TITLE
fix: #43 axios timeout 10s → 60s

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 const client = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
-  timeout: 10_000,
+  timeout: 60_000,
   headers: { 'Content-Type': 'application/json' },
 })
 


### PR DESCRIPTION
Closes #43

좌석 1,000+ 콘서트 생성 시 BE 좌석 풀 INSERT 10s 초과 → axios timeout 회피.
BE 코드 영향 0, 1줄 변경.

상세 진단: 이슈 #43

Phase 2 (발표 후): BE R2DBC batch INSERT로 다시 timeout 짧게 가능.